### PR TITLE
External linking of HD API + Dockerization

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y \
+    python3.11 \
+    python3-pip \
+    xvfb \
+    xauth \
+    wget \
+    curl \
+    gnupg \
+    ca-certificates \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg \
+    https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg] \
+    https://brave-browser-apt-release.s3.brave.com/ stable main" \
+    | tee /etc/apt/sources.list.d/brave-browser.list \
+    && apt-get update \
+    && apt-get install -y brave-browser \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3.11 /usr/bin/python
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN python3.11 -m pip install -r requirements.txt
+RUN python3.11 -m playwright install-deps chromium
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python3.11", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/homedepot/schema.py
+++ b/backend/homedepot/schema.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class Product(BaseModel):
+    itemId: str
+    brand: Optional[str] = None
+    name: Optional[str] = None
+    price: Optional[float] = None
+    image: Optional[str] = None
+    url: Optional[str] = None
+
+class SearchRequest(BaseModel):
+    keyword: str
+    storeId: Optional[str] = "6537"
+    zipCode: Optional[str] = "75150"
+    pageSize: Optional[int] = 12
+
+class SearchResponse(BaseModel):
+    keyword: str
+    products: List[Product]
+    total: Optional[int] = None

--- a/backend/homedepot/search.py
+++ b/backend/homedepot/search.py
@@ -1,0 +1,91 @@
+import re
+import json
+from homedepot.session import HomeDepotSession
+from homedepot.schema import SearchRequest, SearchResponse, Product
+import logging
+
+logger = logging.getLogger(__name__)
+
+def _parse_products(raw_products: list) -> list[Product]:
+    products = []
+    for p in raw_products:
+        identifiers = p.get("identifiers", {})
+        pricing = p.get("pricing") or {}
+        images = p.get("media", {}).get("images", [])
+        image_url = images[0].get("url").replace("<SIZE>", "300") if images else None
+        canonical = identifiers.get("canonicalUrl", "")
+
+        products.append(Product(
+            itemId=p.get("itemId"),
+            brand=identifiers.get("brandName"),
+            name=identifiers.get("productLabel"),
+            price=pricing.get("value"),
+            image=image_url,
+            url=f"https://www.homedepot.com{canonical}" if canonical else None,
+        ))
+    return products
+
+
+async def search_products(
+    session: HomeDepotSession,
+    request: SearchRequest,
+    nav_param: str = "",
+    _redirected: bool = False
+) -> SearchResponse:
+
+    payload = json.loads(json.dumps(session.payload_template))
+    payload["variables"]["keyword"] = request.keyword
+    payload["variables"]["navParam"] = nav_param
+    payload["variables"]["storeId"] = request.storeId
+    payload["variables"]["startIndex"] = 0
+    payload["variables"]["pageSize"] = request.pageSize
+    payload["variables"]["additionalSearchParams"]["deliveryZip"] = request.zipCode or "75150"
+
+    # Fire from inside Brave — bypasses Akamai completely
+    result = await session.page.evaluate("""
+        async ({ url, payload }) => {
+            const resp = await fetch(url, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "x-experience-name": "browse-desktop",
+                    "x-debug": "false",
+                    "x-hd-dc": "origin",
+                },
+                body: JSON.stringify(payload)
+            });
+            const status = resp.status;
+            const data = await resp.json();
+            return { status, data };
+        }
+    """, {"url": session.url, "payload": payload})
+
+    status = result["status"]
+    data = result["data"]
+
+    if status not in (200, 206):
+        logger.error(f"Search failed with status {status}")
+        return SearchResponse(keyword=request.keyword, products=[], total=0)
+
+    search_model = data["data"]["searchModel"]
+
+    redirect = search_model["metadata"].get("searchRedirect")
+    if redirect and not _redirected:
+        match = re.search(r'N-(\w+)', redirect)
+        if match:
+            logger.debug(f"Redirecting to navParam: N-{match.group(1)}")
+            return await search_products(
+                session,
+                request,
+                nav_param=f"N-{match.group(1)}",
+                _redirected=True
+            )
+
+    raw_products = search_model.get("products") or []
+    total = search_model.get("searchReport", {}).get("totalProducts")
+
+    return SearchResponse(
+        keyword=request.keyword,
+        products=_parse_products(raw_products),
+        total=total,
+    )

--- a/backend/homedepot/session.py
+++ b/backend/homedepot/session.py
@@ -1,0 +1,114 @@
+import json
+import asyncio
+import subprocess
+import platform
+import logging
+from playwright.async_api import async_playwright
+
+logger = logging.getLogger(__name__)
+
+class HomeDepotSession:
+
+    def __init__(self):
+        self.url = None
+        self.headers = None
+        self.payload_template = None
+        self.playwright = None
+        self.browser = None
+        self.page = None
+        self._xvfb = None
+        self._display_ready = False
+
+    def _get_browser_path(self) -> str:
+        system = platform.system()
+        if system == "Darwin":
+            return "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+        elif system == "Linux":
+            return "/usr/bin/brave-browser"
+        else:
+            return "C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe"
+
+    def _ensure_display(self):
+        if self._display_ready:
+            return  # already started, don't spawn again
+        
+        if platform.system() == "Linux":
+            import os
+            self._xvfb = subprocess.Popen(
+                ["Xvfb", ":99", "-screen", "0", "1920x1080x24"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
+            )
+            os.environ["DISPLAY"] = ":99"
+            import time
+            time.sleep(2)
+            self._display_ready = True
+            logger.info("Xvfb virtual display started")
+
+    async def init(self):
+        if self.browser:
+            await self.browser.close()
+        if self.playwright:
+            await self.playwright.stop()
+
+        self.url = None
+        self.headers = None
+        self.payload_template = None
+        self._ensure_display()
+
+        self.playwright = await async_playwright().start()
+        self.browser = await self.playwright.chromium.launch(
+            headless=False,
+            executable_path=self._get_browser_path(),
+            args=["--no-sandbox", "--disable-dev-shm-usage"]
+        )
+        self.page = await self.browser.new_page()
+
+        async def handle_route(route, request):
+            if "searchModel" in request.url and self.payload_template is None:
+                try:
+                    self.url = request.url
+                    self.headers = dict(request.headers)
+                    self.payload_template = json.loads(request.post_data)
+                    logger.info(f"Session captured from {self.url}")
+                except Exception as e:
+                    logger.warning(f"Failed to capture request: {e}")
+            await route.continue_()
+
+        await self.page.route("**/*", handle_route)
+
+        await self.page.goto("https://www.homedepot.com")
+        await self.page.wait_for_load_state("domcontentloaded")
+        await self.page.wait_for_timeout(2000)
+
+        attempts = 0
+        while self.payload_template is None and attempts < 3:
+            attempts += 1
+            logger.info(f"Navigation attempt {attempts}/3")
+            await self.page.goto(
+                "https://www.homedepot.com/b/Appliances-Refrigerators-French-Door-Refrigerators/N-5yc1vZc3oo"
+            )
+            await self.page.wait_for_load_state("load")
+            await self.page.evaluate("window.scrollBy(0, 800)")
+            await self.page.wait_for_timeout(2000)
+            await self.page.evaluate("window.scrollBy(0, 800)")
+
+            for i in range(15):
+                if self.payload_template is not None:
+                    break
+                await self.page.wait_for_timeout(1000)
+                logger.debug(f"Waiting for searchModel... [{i+1}/15]")
+
+        if not self.payload_template:
+            raise Exception("Failed to capture searchModel session")
+
+        logger.info("Session ready")
+
+    async def close(self):
+        if self.browser:
+            await self.browser.close()
+        if self.playwright:
+            await self.playwright.stop()
+        if self._xvfb:
+            self._xvfb.terminate()
+            logger.info("Xvfb terminated")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,39 @@
-from fastapi import FastAPI
+import asyncio
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from contextlib import asynccontextmanager
+from projectplanner.service import generate_plan
 from projectplanner.schema import ProjectRequest
-from projectplanner.service import generate_plan 
+from homedepot.session import HomeDepotSession
+from homedepot.search import search_products
+from homedepot.schema import SearchRequest, SearchResponse
+import traceback
+import logging
 
-app = FastAPI()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+logger = logging.getLogger(__name__)
+hd_session = HomeDepotSession()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Booting Home Depot session")
+    try:
+        await asyncio.wait_for(hd_session.init(), timeout=120)
+        logger.info("Session booted successfully")
+    except asyncio.TimeoutError:
+        logger.error("Session init timed out after 120s")
+    except Exception as e:
+        logger.exception(f"Session boot failed: {e}")
+    yield
+    logger.info("Shutting down")
+    await hd_session.close()
+
+app = FastAPI(lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -15,3 +45,17 @@ app.add_middleware(
 @app.post("/generate-plan")
 def generate(request: ProjectRequest):
     return generate_plan(request.input)
+
+@app.post("/homedepot/search", response_model=SearchResponse)
+async def search(request: SearchRequest):
+    try:
+        return await search_products(hd_session, request)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/health")
+async def health():
+    return {
+        "status": "ok",
+        "session_ready": hd_session.payload_template is not None
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,7 @@ fastapi
 uvicorn
 openai
 python-dotenv
+requests
+httpx
+playwright
+pyvirtualdisplay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    environment:
+      - DISPLAY=:99
+      - PYTHONUNBUFFERED=1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "frontend": "vite",
-    "dev": "concurrently \"uvicorn main:app --reload --app-dir \"../backend\"\" \"npm run frontend\"",
+    "dev": "concurrently \"docker compose -f ../docker-compose.yml up backend\" \"npm run frontend\"",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
- ok...so as it turns out, fetching the actual Home Depot API would be hard and it requires a bit of ingenuity in seeing how it unfolds
 - therefore...doing some network analysis and some initial prototyping...i figured out that invoking this API requires one to be in a browsing instance and then do a simple redirect to yield results to browser and fetch results
- so initially I wanted to leave it as is...but then I figured if one wanted to host this on the cloud...then you might need to resort to dockerizing this
  - in my physical diagram...I kinda hinted at having this solution to happen through K8s happening
    - after a bit of development effort, I finally got the scaffold to work and was able to dockerize the backend
      - this is also hooked up to the npm command and should be solid for anyone to now run `npm run dev`