### PR TITLE
Polling backend logic to frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,17 +18,21 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 hd_session = HomeDepotSession()
+session_error: str | None = None
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    global session_error
     logger.info("Booting Home Depot session")
     try:
         await asyncio.wait_for(hd_session.init(), timeout=120)
         logger.info("Session booted successfully")
     except asyncio.TimeoutError:
-        logger.error("Session init timed out after 120s")
+        session_error = "Session init timed out after 120s"
+        logger.error(session_error)
     except Exception as e:
-        logger.exception(f"Session boot failed: {e}")
+        session_error = f"Session boot failed: {e}"
+        logger.exception(session_error)
     yield
     logger.info("Shutting down")
     await hd_session.close()
@@ -57,5 +61,6 @@ async def search(request: SearchRequest):
 async def health():
     return {
         "status": "ok",
-        "session_ready": hd_session.payload_template is not None
+        "session_ready": hd_session.payload_template is not None,
+        "session_error": session_error,
     }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -2,8 +2,12 @@ import { Outlet } from 'react-router-dom'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import AppSidebar from './Sidebar'
 import Navbar from './Navbar'
+import { useBackendReady } from '@/hooks/useBackendReady'
 
 export default function Layout() {
+    const { ready, checking, error } = useBackendReady()
+
+
     return (
         <SidebarProvider>
             <div className="flex h-screen w-full overflow-hidden">
@@ -15,6 +19,22 @@ export default function Layout() {
                     </main>
                 </div>
             </div>
+
+            {checking && !ready && !error && (
+                <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/80 backdrop-blur-sm">
+                    <div className="animate-spin rounded-full h-10 w-10 border-4 border-orange-500 border-t-transparent mb-4" />
+                    <p className="text-gray-700 font-medium">Starting backend…</p>
+                    <p className="text-gray-400 text-sm mt-1">This takes ~15s on first boot</p>
+                </div>
+            )}
+
+            {error && (
+                <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/80 backdrop-blur-sm">
+                    <div className="text-red-500 text-4xl mb-4">⚠</div>
+                    <p className="text-gray-800 font-semibold">Backend failed to start</p>
+                    <p className="text-red-400 text-sm mt-2 max-w-sm text-center">{error}</p>
+                </div>
+            )}
         </SidebarProvider>
     )
 }

--- a/frontend/src/hooks/useBackendReady.ts
+++ b/frontend/src/hooks/useBackendReady.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react"
+
+export function useBackendReady(intervalMs = 2000) {
+    const [ready, setReady] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [checking, setChecking] = useState(true)
+  
+    useEffect(() => {
+      let cancelled = false
+  
+      async function poll() {
+        try {
+          const res = await fetch('http://localhost:8000/health')
+          const json = await res.json()
+  
+          if (json.session_ready) {
+            if (!cancelled) { setReady(true); setChecking(false) }
+            return
+          }
+  
+          if (json.session_error) {
+            if (!cancelled) { setError(json.session_error); setChecking(false) }
+            return
+          }
+        } catch {
+            // not yet open...keep polling
+        }
+  
+        if (!cancelled) setTimeout(poll, intervalMs)
+      }
+  
+      poll()
+      return () => { cancelled = true }
+    }, [intervalMs])
+  
+    return { ready, checking, error }
+  }


### PR DESCRIPTION
- for when the backend is launching...we want to make sure that users don't interact with our website to prevent false hope of our application not working when the backend hasn't initialized yet
  - therefore...polling logic is builtin to now block the screen until the backend has loaded OR show an error that indicates something happened to loading the backend