### PR TITLE
Flaky SKU test fix + added in test case 06 implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: frontend
 
       - name: Run Vitest

--- a/backend/tests/test_sku_validation.py
+++ b/backend/tests/test_sku_validation.py
@@ -4,7 +4,7 @@ from homedepot.schema import SearchRequest
 def test_sku_in_search_results(hd_session, hd_loop, project_plan):
     for item in project_plan["materials"] + project_plan["tools"]:
         store_id = hd_loop.run_until_complete(hd_session.resolve_zip(item["zip"]))
-        request = SearchRequest(keyword=item["name"], storeId=store_id, pageSize=5)
+        request = SearchRequest(keyword=item["sku"], storeId=store_id, pageSize=5)
         response = hd_loop.run_until_complete(search_products(hd_session, request))
 
         matched = next((p for p in response.products if p.itemId == item["sku"]), None)

--- a/frontend/src/__tests__/costBreakdown.test.tsx
+++ b/frontend/src/__tests__/costBreakdown.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import Cart from '@/pages/Cart'
+import Cart from '../pages/Cart'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 const mockItems = [
@@ -20,16 +20,16 @@ afterEach(() => {
 
 test('displays correct subtotal', () => {
   render(<MemoryRouter><Cart /></MemoryRouter>)
-  expect(screen.getByText('$162.97')).toBeInTheDocument()
+  expect(screen.getAllByText('$162.97').length).toBeGreaterThan(0)
 })
 
 test('displays correct tax for Texas zip', () => {
   render(<MemoryRouter><Cart /></MemoryRouter>)
   expect(screen.getByText('Estimated Sales Tax (8.25%)')).toBeInTheDocument()
-  expect(screen.getByText('$13.44')).toBeInTheDocument()
+  expect(screen.getByText('$13.45')).toBeInTheDocument()
 })
 
 test('total equals subtotal plus tax', () => {
   render(<MemoryRouter><Cart /></MemoryRouter>)
-  expect(screen.getByText('$176.41')).toBeInTheDocument()
+  expect(screen.getByText('$176.42')).toBeInTheDocument()
 })

--- a/frontend/src/__tests__/generatePlan.test.ts
+++ b/frontend/src/__tests__/generatePlan.test.ts
@@ -33,5 +33,5 @@ describe('POST /generate-plan', () => {
     expect(data.materials.length).toBeGreaterThan(0)
     expect(data.tools.length).toBeGreaterThan(0)
     expect(data.steps.length).toBeGreaterThan(0)
-  }, 30000)
+  }, 60000)
 })

--- a/frontend/src/__tests__/productRecommendations.test.tsx
+++ b/frontend/src/__tests__/productRecommendations.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import CostEstimate from '../pages/CostEstimate' // adjust path
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+const mockPlanState = {
+    overview: 'Tile bathroom',
+    materials: [{ id: 1, name: 'Ceramic Tile', quantity: '114', unit: 'sq ft' }],
+    tools: [{ id: 1, name: 'Tile saw' }],
+    steps: [],
+    input: 'Retile my bathroom',
+}
+
+const mockProduct = { itemId: '123', name: 'Ceramic Floor Tile', brand: 'HDX', price: 2.50, image: '', url: '' }
+const mockRec = { item_id: '999', name: 'Tile Spacers', category: 'Flooring', score: 85, price: 4.99, image: '', url: '' }
+
+beforeEach(() => {
+    localStorage.clear()
+    globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/homedepot/search')) {
+            return Promise.resolve({ json: () => Promise.resolve({ products: [mockProduct] }) })
+        }
+        if (url.includes('/homedepot/recommendations')) {
+            return Promise.resolve({ json: () => Promise.resolve([mockRec]) })
+        }
+        if (url.includes('/events/sku')) {
+            return Promise.resolve({ json: () => Promise.resolve({ ok: true }) })
+        }
+        return Promise.resolve({ json: () => Promise.resolve({}) })
+    })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+function renderWithState() {
+    return render(
+        <MemoryRouter initialEntries={[{ pathname: '/cost', state: mockPlanState }]}>
+            <Routes>
+                <Route path="/cost" element={<CostEstimate />} />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+test('recommendations appear with name and price', async () => {
+    renderWithState()
+    await waitFor(() => expect(screen.getByText('Tile Spacers')).toBeInTheDocument())
+    expect(screen.getByText('$4.99')).toBeInTheDocument()
+})
+
+test('adding rec to cart stores it in localStorage', async () => {
+    renderWithState()
+    await waitFor(() => screen.getByText('Tile Spacers'))
+
+    const recCard = screen.getByText('Tile Spacers').closest('div')!
+    await act(async () => {
+        fireEvent.click(within(recCard).getByText('Add to cart'))
+    })
+
+    const cart = JSON.parse(localStorage.getItem('buildsmart_cart') ?? '[]')
+    expect(cart.length).toBe(1)
+    expect(cart[0].product.itemId).toBe('999')
+})
+
+test('adding same item twice does not duplicate', async () => {
+    renderWithState()
+    await waitFor(() => screen.getByText('Tile Spacers'))
+
+    const btn = screen.getAllByText('Add to cart')[0]
+    await act(async () => { fireEvent.click(btn) })
+    await act(async () => { fireEvent.click(btn) })
+
+    const cart = JSON.parse(localStorage.getItem('buildsmart_cart') ?? '[]')
+    expect(cart.length).toBe(1)
+    expect(cart[0].qty).toBe(2)
+})

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,1 +1,31 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+class IntersectionObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+globalThis.IntersectionObserver = IntersectionObserverMock as any
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+globalThis.ResizeObserver = ResizeObserverMock as any
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+  })),
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
 
 export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
- got test case #06 implementation fixed with a bit of trouble but good to go i hope
- add back the npm ci command
- flaky SKU test where it was actually not looking up via sku. It rather worked via top 5 results

Will close #50 <-- product recs test 